### PR TITLE
Added the ability to configure application insights with a ITelemetryChannel 

### DIFF
--- a/src/App.Metrics.Reporting.ApplicationInsights/ApplicationInsightsReporter.cs
+++ b/src/App.Metrics.Reporting.ApplicationInsights/ApplicationInsightsReporter.cs
@@ -47,7 +47,7 @@ namespace App.Metrics.Reporting.ApplicationInsights
             }
 
             this.translator = translator ?? throw new ArgumentNullException(nameof(translator));
-            clientCfg = new TelemetryConfiguration(options.InstrumentationKey);
+            clientCfg = new TelemetryConfiguration(options.InstrumentationKey, options.ITelemetryChannel);
             client = new TelemetryClient(clientCfg);
             FlushInterval = options.FlushInterval > TimeSpan.Zero
                 ? options.FlushInterval

--- a/src/App.Metrics.Reporting.ApplicationInsights/ApplicationInsightsReporterOptions.cs
+++ b/src/App.Metrics.Reporting.ApplicationInsights/ApplicationInsightsReporterOptions.cs
@@ -2,6 +2,7 @@ namespace App.Metrics.Reporting.ApplicationInsights
 {
     using App.Metrics.Filters;
     using System;
+    using Microsoft.ApplicationInsights.Channel;
 
     /// <summary>
     /// Provides programmatic configuration of Microsoft Application Insights reporting in the App Metrics framework.
@@ -12,6 +13,11 @@ namespace App.Metrics.Reporting.ApplicationInsights
         ///     Application Insights instrumentation key.
         /// </summary>
         public string InstrumentationKey { get; set; }
+
+        /// <summary>
+        ///     Application Insights telemetry channel to provide with this configuration instance
+        /// </summary>
+        public ITelemetryChannel ITelemetryChannel { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IFilterMetrics" /> to use for just this reporter.


### PR DESCRIPTION
I need to be able to configure my application insights instance with an `ITelemetryChannel`. Thought this might be useful to others since the cost of doing so is low.

https://docs.microsoft.com/en-us/azure/azure-monitor/app/telemetry-channels#:~:text=What%20are%20telemetry%20channels%3F,ApplicationInsights.